### PR TITLE
added dash to element name to make it specs-conform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# &lt;twitter&gt;
+# &lt;my-twitter&gt;
 
 Web Component wrapper for [Twitter's share button](https://twitter.com/about/resources/buttons#tweet) using Polymer.
 
@@ -21,13 +21,13 @@ Web Component wrapper for [Twitter's share button](https://twitter.com/about/res
 2. Import Custom Element:
 
   ```html
-  <link rel="import" href="src/twitter.html">
+  <link rel="import" href="src/my-twitter.html">
   ```
 
 3. Start using it!
 
   ```xml
-  <twitter></twitter>
+  <my-twitter></my-twitter>
   ```
 
 ## Options

--- a/index.html
+++ b/index.html
@@ -2,30 +2,30 @@
 <html>
 <head>
 	<meta charset="UTF-8">
-	<title>&lt;twitter&gt;</title>
+	<title>&lt;my-twitter&gt;</title>
 
 	<!-- Importing Web Component's Polyfill -->
 	<script src="//cdnjs.cloudflare.com/ajax/libs/polymer/0.0.20130816/polymer.min.js"></script>
 
 	<!-- Importing Custom Elements -->
-	<link rel="import" href="src/twitter.html">
+	<link rel="import" href="src/my-twitter.html">
 </head>
 <body>
 
 	<!-- Using Custom Elements -->
-	<twitter type="share" width="300"></twitter>
+	<my-twitter type="share" width="300"></my-twitter>
 
 	<br><br>
 
-	<twitter type="follow" width="300"></twitter>
+	<my-twitter type="follow" width="300"></my-twitter>
 
 	<br><br>
 
-	<twitter type="hashtag" width="300"></twitter>
+	<my-twitter type="hashtag" width="300"></my-twitter>
 
 	<br><br>
 
-	<twitter type="mention" width="300"></twitter>
+	<my-twitter type="mention" width="300"></my-twitter>
 
 </body>
 </html>

--- a/src/my-twitter.html
+++ b/src/my-twitter.html
@@ -1,4 +1,4 @@
-<polymer-element name="twitter" attributes="text type href user height width">
+<polymer-element name="my-twitter" attributes="text type href user height width">
 
 	<template>
 		<template if="{{type == 'follow'}}">
@@ -26,7 +26,7 @@
 	</template>
 
 	<script>
-		Polymer('twitter', {
+		Polymer('my-twitter', {
 			text   : 'Custom Elements rocks!',
 			href   : 'http://customelements.io',
 			user   : 'zenorocha',


### PR DESCRIPTION
Hi.

I tried your demo in Chrome 31.0.1623.0 canary and it didn't work due to the missing dash in the element's name as proposed by the specs (http://www.w3.org/TR/2013/WD-custom-elements-20130514/#terminology).

best regards
emanuel
