### PR TITLE
Encode text using encodeURIComponent()

### DIFF
--- a/dist/twitter-button.html
+++ b/dist/twitter-button.html
@@ -5,21 +5,7 @@
 <polymer-element name="twitter-button" attributes="text type href user hashtag height width">
 
     <template>
-        <template if="{{type == 'follow'}}">
-            <iframe src="https://platform.twitter.com/widgets/follow_button.html?screen_name={{user}}" allowtransparency="true" frameborder="0" scrolling="no"></iframe>
-        </template>
-
-        <template if="{{type == 'share'}}">
-            <iframe src="http://platform.twitter.com/widgets/tweet_button.html?url={{href}}&amp;via={{user}}&amp;text={{text}}" allowtransparency="true" frameborder="0" scrolling="no"></iframe>
-        </template>
-
-        <template if="{{type == 'hashtag'}}">
-            <iframe src="https://platform.twitter.com/widgets/tweet_button.html?text={{text}}&amp;button_hashtag={{hashtag}}&amp;type=hashtag" allowtransparency="true" frameborder="0" scrolling="no"></iframe>
-        </template>
-
-        <template if="{{type == 'mention'}}">
-            <iframe src="https://platform.twitter.com/widgets/tweet_button.html?screen_name={{user}}&amp;type=mention" allowtransparency="true" frameborder="0" scrolling="no"></iframe>
-        </template>
+        <iframe src="{{src}}" allowtransparency="true" frameborder="0" scrolling="no"></iframe>
 
         <style>
             iframe {
@@ -31,13 +17,33 @@
 
     <script>
         Polymer('twitter-button', {
-            text   : 'Custom Elements rocks!',
-            href   : 'http://customelements.io',
-            user   : 'zenorocha',
-            hashtag: 'customelements',
+            text   : 'Web Components rocks!',
+            href   : 'http://webcomponents.org',
+            user   : 'Web_Components',
+            hashtag: 'webcomponents',
             height : '25',
             width  : '115',
-            type   : 'share'
+            type   : 'share',
+            ready  : function() {
+                if (this.type == 'follow') {
+                    var src = 'https://platform.twitter.com/widgets/follow_button.html?screen_name=' + this.user;
+                } else {
+                    var src = 'https://platform.twitter.com/widgets/tweet_button.html?text=' + encodeURIComponent(this.text);
+                    switch (this.type) {
+                        case 'share':
+                            if (this.href != undefined) src += '&url=' + this.href;
+                            src += '&via=' + this.user;
+                            break;
+                        case 'hashtag':
+                            src += '&button_hashtag=' + this.hashtag + '&type=hashtag';
+                            break;
+                        case 'mention':
+                            src += '&screen_name=' + this.user + '&type=mention';
+                            break;
+                    }
+                }
+                this.src = src;
+            }
         });
     </script>
 

--- a/src/twitter-button.html
+++ b/src/twitter-button.html
@@ -5,21 +5,7 @@
 <polymer-element name="twitter-button" attributes="text type href user hashtag height width">
 
     <template>
-        <template if="{{type == 'follow'}}">
-            <iframe src="https://platform.twitter.com/widgets/follow_button.html?screen_name={{user}}" allowtransparency="true" frameborder="0" scrolling="no"></iframe>
-        </template>
-
-        <template if="{{type == 'share'}}">
-            <iframe src="http://platform.twitter.com/widgets/tweet_button.html?url={{href}}&amp;via={{user}}&amp;text={{text}}" allowtransparency="true" frameborder="0" scrolling="no"></iframe>
-        </template>
-
-        <template if="{{type == 'hashtag'}}">
-            <iframe src="https://platform.twitter.com/widgets/tweet_button.html?text={{text}}&amp;button_hashtag={{hashtag}}&amp;type=hashtag" allowtransparency="true" frameborder="0" scrolling="no"></iframe>
-        </template>
-
-        <template if="{{type == 'mention'}}">
-            <iframe src="https://platform.twitter.com/widgets/tweet_button.html?screen_name={{user}}&amp;type=mention" allowtransparency="true" frameborder="0" scrolling="no"></iframe>
-        </template>
+        <iframe src="{{src}}" allowtransparency="true" frameborder="0" scrolling="no"></iframe>
 
         <style>
             iframe {
@@ -37,7 +23,27 @@
             hashtag: 'webcomponents',
             height : '25',
             width  : '115',
-            type   : 'share'
+            type   : 'share',
+            ready  : function() {
+                if (this.type == 'follow') {
+                    var src = 'https://platform.twitter.com/widgets/follow_button.html?screen_name=' + this.user;
+                } else {
+                    var src = 'https://platform.twitter.com/widgets/tweet_button.html?text=' + encodeURIComponent(this.text);
+                    switch (this.type) {
+                        case 'share':
+                            if (this.href != undefined) src += '&url=' + this.href;
+                            src += '&via=' + this.user;
+                            break;
+                        case 'hashtag':
+                            src += '&button_hashtag=' + this.hashtag + '&type=hashtag';
+                            break;
+                        case 'mention':
+                            src += '&screen_name=' + this.user + '&type=mention';
+                            break;
+                    }
+                }
+                this.src = src;
+            }
         });
     </script>
 


### PR DESCRIPTION
Please try `text="git + hub = github"` :octocat: 
## Expected:

![](http://i.gyazo.com/10998bf168de8607e1234c92907777a9.png)
## Got:

![](http://i.gyazo.com/b9ce829a1fac9c945d0aa16c68054db2.png)
I would rather not change construction of `<template>`, but couldn't do it well. :bow:

By the way, I would suggest separating `type='follow'` as `<twitter-follow>` from the others.
If you like it, you can simplify`<template>` and be easy to maintain.  :+1: 
